### PR TITLE
Change sh to bash

### DIFF
--- a/aws-setup.sh
+++ b/aws-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Create a VPC, Subnet, and Security Group required by jmeter-ecs
 


### PR DESCRIPTION
The `if [` is incorrect syntax for Shell and raise the errors like:
```
./aws-setup.sh: 8: [: unexpected operator
```
I've changed it to `/bin/bash`