### PR TITLE
Supporting JMeter 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,9 @@ The following required and optional environment variables are supported:
 |SECURITY_GROUP|Yes|None|AWS Secuirty group that allows ports 22,1099,50000,51000/tcp and 4445/udp from all ports (e.g. sg-12345678)|
 |SUBNET_ID|Yes|None|One or more Subnets (comma separated) that are assigned to your VPC|
 |VPC_ID||VPC assigned to SUBNET_ID|We dautomatically erive this from your SUBNET_ID|
-|JMETER_VERSION||latest|smithmicro/lucy Image tag.  See Docker Hub for [available versions](https://hub.docker.com/r/smithmicro/jmeter/tags/).|
+|JMETER_VERSION||latest|smithmicro/jmeter Image tag.  See Docker Hub for [available versions](https://hub.docker.com/r/smithmicro/jmeter/tags/).|
 |INSTANCE_TYPE||t2.micro|To double your memory, pass `t2.small`|
 |MEM_LIMIT||950m|If you are using t2.small, set MEM_LIMIT to `1995m`|
-|JMETER_MEMORY||-Xms800m -Xmx800m|If you are using t2.small, set JMETER_MEMORY to `Xms1600m -Xmx1600m`|
 |MINION_COUNT||2||
 |PEM_PATH||/keys|This must match your Volume map.  See Volume section above.|
 |CLUSTER_NAME||JMeter|Name that appears in your AWS Cluster UI|

--- a/aws-setup.sh
+++ b/aws-setup.sh
@@ -20,6 +20,9 @@ fi
 if [ "$OWNER" == '' ]; then
   OWNER=jmeter-ecs
 fi
+if [ "$AWS_REGION" == '' ]; then
+  AWS_REGION=$(aws configure get region)
+fi
 
 # keep the tags consistant so we can easily detect if a JMeter VPC already exists
 VPC_TAGS="Key=Name,Value=JMeter-VPC Key=Owner,Value=$OWNER Key=Stack,Value=JMeter"
@@ -43,10 +46,10 @@ echo "Created VPC $VPC_ID"
 # enable DNS hostnames
 aws ec2 modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-hostnames --output text
 
-# create a 2 subnets
-SUBNET_ID1=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $SUBNET_CIDR_BLOCK1 \
+# create 2 subnets
+SUBNET_ID1=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $SUBNET_CIDR_BLOCK1 --availability-zone "$AWS_REGION"a \
     --query 'Subnet.[SubnetId]' --output text | tr -d '\n')
-SUBNET_ID2=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $SUBNET_CIDR_BLOCK2 \
+SUBNET_ID2=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $SUBNET_CIDR_BLOCK2 --availability-zone "$AWS_REGION"b \
     --query 'Subnet.[SubnetId]' --output text | tr -d '\n')
 echo "Created Subnets $SUBNET_ID1,$SUBNET_ID2"
 

--- a/aws-setup.sh
+++ b/aws-setup.sh
@@ -81,7 +81,7 @@ aws ec2 modify-subnet-attribute --subnet-id $SUBNET_ID2 --map-public-ip-on-launc
 SG_ID=$(aws ec2 create-security-group --group-name "JMeter" --description "JMeter Security Group" --vpc-id $VPC_ID --output text | tr -d '\n')
 echo "Created Security Group $SG_ID"
 
-JMETER_IP_PERMISSIONS='[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 1099, "ToPort": 1099, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "udp", "FromPort": 4445, "ToPort": 4445, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 50000, "ToPort": 50000, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 51000, "ToPort": 51000, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
+JMETER_IP_PERMISSIONS='[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 1099, "ToPort": 1099, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "udp", "FromPort": 4445, "ToPort": 4445, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 50000, "ToPort": 50000, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]},{"IpProtocol": "tcp", "FromPort": 51000, "ToPort": 51999, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
 aws ec2 authorize-security-group-ingress --group-id $SG_ID --ip-permissions "$JMETER_IP_PERMISSIONS"
 
 # tag all created resources

--- a/jmeter/3.0/Dockerfile
+++ b/jmeter/3.0/Dockerfile
@@ -11,7 +11,7 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
+ENV JMETER_MEMORY -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/3.1/Dockerfile
+++ b/jmeter/3.1/Dockerfile
@@ -11,7 +11,7 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
+ENV JMETER_MEMORY -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/3.2/Dockerfile
+++ b/jmeter/3.2/Dockerfile
@@ -11,7 +11,7 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
+ENV JMETER_MEMORY -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/3.3/Dockerfile
+++ b/jmeter/3.3/Dockerfile
@@ -11,7 +11,7 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
+ENV JMETER_MEMORY -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/4.0/Dockerfile
+++ b/jmeter/4.0/Dockerfile
@@ -11,7 +11,6 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/4.0/Dockerfile
+++ b/jmeter/4.0/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-alpine
 
 LABEL maintainer="David Sperling <dsperling@smithmicro.com>"
 
-ENV JMETER_VERSION apache-jmeter-5.0
+ENV JMETER_VERSION apache-jmeter-4.0
 ENV JMETER_HOME /opt/$JMETER_VERSION
 ENV PATH $PATH:$JMETER_HOME/bin
 ENV CMDRUNNER_VERSION 2.2

--- a/jmeter/4.0/entrypoint.sh
+++ b/jmeter/4.0/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Main entrypoint for our Docker image - runs Gru, Minions or other commands
+
+# any .jmx file passed in the command line we act as 'Gru'
+if [ ${1##*.} = 'jmx' ]; then
+
+  if [ "$MINION_HOSTS" = '' ]; then
+    echo "MINION_HOSTS must be specified - a command separated list of hostnames or IP addresses"
+    exit 1
+  fi
+  echo "Connecting to $MINION_HOSTS"
+
+  # AWS Public HOSTNAME API
+  echo "Detecting an AWS Environment"
+  PUBLIC_HOSTNAME=$(curl -s --max-time 5 http://169.254.169.254/latest/meta-data/public-hostname)
+
+  if [ "$PUBLIC_HOSTNAME" = '' ]; then
+    echo "Not running in AWS.  Using Gru HOSTNAME $HOSTNAME"
+  else
+    HOSTNAME=$PUBLIC_HOSTNAME
+    echo "Using Gru AWS Public HOSTNAME $HOSTNAME"
+  fi
+  # empty the logs directory, or jmeter may fail
+  rm -rf /logs/report /logs/*.log /logs/*.jtl
+
+  # set JAVA HEAP
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
+
+  # run jmeter in client (gru) mode
+  exec jmeter -n $JMETER_FLAGS \
+    -R $MINION_HOSTS \
+    -Dclient.rmi.localport=51000 \
+    -Dserver.rmi.ssl.disable=true \
+    -Djava.rmi.server.hostname=${PUBLIC_HOSTNAME} \
+    -l $RESULTS_LOG \
+    -t $1 \
+    -e -o /logs/report
+
+fi
+
+# act as a 'Minion'
+if [ "$1" = 'minion' ]; then
+
+  # AWS Public HOSTNAME API
+  echo "Detecting an AWS Environment"
+  PUBLIC_HOSTNAME=$(curl -s --max-time 5 http://169.254.169.254/latest/meta-data/public-hostname)
+
+  if [ "$PUBLIC_HOSTNAME" = '' ]; then
+    echo "Not running in AWS.  Using Minion HOSTNAME $HOSTNAME"
+  else
+    HOSTNAME=$PUBLIC_HOSTNAME
+    echo "Using Minion AWS Public HOSTNAME $HOSTNAME"
+  fi
+
+  # set JAVA HEAP
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
+
+  # install custom plugin if requested
+  if [ "$CUSTOM_PLUGIN_URL" != '' ]; then
+    echo "Installing custom plugin $CUSTOM_PLUGIN_URL"
+    CUSTOM_PLUGIN_FILE="${CUSTOM_PLUGIN_URL##*/}"
+    curl -o $JMETER_HOME/lib/ext/$CUSTOM_PLUGIN_FILE $CUSTOM_PLUGIN_URL
+  fi
+
+  # run jmeter in server (minion) mode
+  exec jmeter-server -n \
+    -Dserver.rmi.localport=50000 \
+    -Dserver.rmi.ssl.disable=true \
+    -Djava.rmi.server.hostname=${HOSTNAME}
+
+fi
+
+exec "$@"

--- a/jmeter/4.0/entrypoint.sh
+++ b/jmeter/4.0/entrypoint.sh
@@ -24,8 +24,9 @@ if [ ${1##*.} = 'jmx' ]; then
   # empty the logs directory, or jmeter may fail
   rm -rf /logs/report /logs/*.log /logs/*.jtl
 
-  # set JAVA HEAP
-  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
+  # remove setting JAVA heap and use the RUN_IN_DOCKER variable
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m//' $JMETER_HOME/bin/jmeter
+  sed -i 's/# RUN_IN_DOCKER/RUN_IN_DOCKER/' $JMETER_HOME/bin/jmeter
 
   # run jmeter in client (gru) mode
   exec jmeter -n $JMETER_FLAGS \
@@ -53,8 +54,9 @@ if [ "$1" = 'minion' ]; then
     echo "Using Minion AWS Public HOSTNAME $HOSTNAME"
   fi
 
-  # set JAVA HEAP
-  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
+  # remove setting JAVA heap and use the RUN_IN_DOCKER variable
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m//' $JMETER_HOME/bin/jmeter
+  sed -i 's/# RUN_IN_DOCKER/RUN_IN_DOCKER/' $JMETER_HOME/bin/jmeter
 
   # install custom plugin if requested
   if [ "$CUSTOM_PLUGIN_URL" != '' ]; then

--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -11,7 +11,6 @@ ENV PLUGINMGR_VERSION 1.3
 # overridable environment variables
 ENV RESULTS_LOG results.jtl
 ENV JMETER_FLAGS=
-ENV JMETER_MEMORY -Xms800m -Xmx800m
 ENV CUSTOM_PLUGIN_URL=
 
 # Install the required tools for JMeter

--- a/jmeter/entrypoint.sh
+++ b/jmeter/entrypoint.sh
@@ -24,9 +24,10 @@ if [ ${1##*.} = 'jmx' ]; then
   # empty the logs directory, or jmeter may fail
   rm -rf /logs/report /logs/*.log /logs/*.jtl
 
-  # set JAVA HEAP
-  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
-
+  # remove setting JAVA heap and use the RUN_IN_DOCKER variable
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m//' $JMETER_HOME/bin/jmeter
+  sed -i 's/# RUN_IN_DOCKER/RUN_IN_DOCKER/' $JMETER_HOME/bin/jmeter
+  
   # run jmeter in client (gru) mode
   exec jmeter -n $JMETER_FLAGS \
     -R $MINION_HOSTS \
@@ -53,9 +54,10 @@ if [ "$1" = 'minion' ]; then
     echo "Using Minion AWS Public HOSTNAME $HOSTNAME"
   fi
 
-  # set JAVA HEAP
-  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m/'"$JMETER_MEMORY"'/' $JMETER_HOME/bin/jmeter
-
+  # remove setting JAVA heap and use the RUN_IN_DOCKER variable
+  sed -i 's/-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m//' $JMETER_HOME/bin/jmeter
+  sed -i 's/# RUN_IN_DOCKER/RUN_IN_DOCKER/' $JMETER_HOME/bin/jmeter
+  
   # install custom plugin if requested
   if [ "$CUSTOM_PLUGIN_URL" != '' ]; then
     echo "Installing custom plugin $CUSTOM_PLUGIN_URL"

--- a/lucy/Dockerfile
+++ b/lucy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 LABEL maintainer="David Sperling <dsperling@smithmicro.com>"
 


### PR DESCRIPTION
- Removed need for JMETER_MEMORY.  Taking advantage of DOCKER support in JAVA 8
- Now using `--network host` for Gru
- Expanded the Gru port ranges to 51000-51999 in `aws-setup.sh`
- Bug fixes in `lucy.sh`
- Fix for #23.  Now properly passing JMETER_FLAGS to Gru